### PR TITLE
Fix MainWindow API

### DIFF
--- a/mindmap/gui/main_window.py
+++ b/mindmap/gui/main_window.py
@@ -18,4 +18,6 @@ class MainWindow:
         self.toolbar = Toolbar(self.root, self.canvas)
         self.toolbar.pack(side=tk.TOP, fill=tk.X)
 
+    def run(self):
+        """Start the Tkinter main loop."""
         self.root.mainloop()


### PR DESCRIPTION
## Summary
- add missing `run` method to `MainWindow`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684434b8350083289ffb2bb73d020e2b